### PR TITLE
Implemented Invoke-PMInstall

### DIFF
--- a/ProgramManager/ProgramManager.psd1
+++ b/ProgramManager/ProgramManager.psd1
@@ -42,6 +42,7 @@
 	# Functions to export from this module
 	FunctionsToExport = @(
 		'Add-PMProgram',
+		'Invoke-PMInstall',
 		'Import-Data',
 		'Export-Data'
 	)

--- a/ProgramManager/functions/Add-PMProgram.ps1
+++ b/ProgramManager/functions/Add-PMProgram.ps1
@@ -40,6 +40,12 @@
 	.PARAMETER Note
 		A short note/description to explain what the package entry is. Optonal
 		
+	.PARAMETER PreInstallScriptblock
+		A script block which will be executed before the main package installation process.
+		
+	.PARAMETER PostInstallScriptblock
+		A script block which will be executed after the main package installation process.
+		
 	.EXAMPLE
 		PS C:\> Add-PMProgram -Name "chrome" -LocalPackage -PackageLocation "C:\Users\<user>\Downloads\chrome.msi" -Note "Chrome msi installer"
 		
@@ -89,14 +95,29 @@
 		[Parameter(ParameterSetName = "ChocolateyPackage", Mandatory = $true, Position = 2)]
 		[string]
 		$PackageName,
-				
+		
 		
 		[Parameter(ParameterSetName = "LocalPackage")]
 		[Parameter(ParameterSetName = "UrlPackage")]
 		[Parameter(ParameterSetName = "PortablePackage")]
 		[Parameter(ParameterSetName = "ChocolateyPackage")]
 		[string]
-		$Note
+		$Note,
+		
+		[Parameter(ParameterSetName = "LocalPackage")]
+		[Parameter(ParameterSetName = "UrlPackage")]
+		[Parameter(ParameterSetName = "PortablePackage")]
+		[Parameter(ParameterSetName = "ChocolateyPackage")]
+		[scriptblock]
+		$PreInstallScriptblock,
+		
+		[Parameter(ParameterSetName = "LocalPackage")]
+		[Parameter(ParameterSetName = "UrlPackage")]
+		[Parameter(ParameterSetName = "PortablePackage")]
+		[Parameter(ParameterSetName = "ChocolateyPackage")]
+		[scriptblock]
+		$PostInstallScriptblock
+		
 	)
 	
 	$dataPath = "$env:USERPROFILE\ProgramManager"
@@ -248,6 +269,16 @@
 	if ([System.String]::IsNullOrWhiteSpace($Note) -eq $false) {
 		$package | Add-Member -Type NoteProperty -Name "Note" -Value $Note		
 	}
+	
+	# Add optional scriptblock properties if passed in
+	if ([System.String]::IsNullOrWhiteSpace($PreInstallScriptblock) -eq $false) {
+		$package | Add-Member -Type NoteProperty -Name "PreInstallScriptblock" -Value $PreInstallScriptblock
+	}
+	
+	if ([System.String]::IsNullOrWhiteSpace($PostInstallScriptblock) -eq $false) {
+		$package | Add-Member -Type NoteProperty -Name "PostInstallScriptblock" -Value $PostInstallScriptblock
+	}
+	
 	
 	# Add new PMpackage to list
 	$packageList.Add($package)

--- a/ProgramManager/functions/Add-PMProgram.ps1
+++ b/ProgramManager/functions/Add-PMProgram.ps1
@@ -189,7 +189,6 @@
 		if ((Get-Item -Path $PackageLocation).PSIsContainer -eq $true) {
 			
 			# This is a folder so can be moved straight to the package store
-			$folder = Get-Item -Path $PackageLocation
 			Move-Item -Path $PackageLocation -Destination "$dataPath\packages\$Name"
 						
 			Remove-Item -Path "$dataPath\temp" -Recurse -Force

--- a/ProgramManager/functions/Invoke-PMInstall.ps1
+++ b/ProgramManager/functions/Invoke-PMInstall.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
         Installs a ProgramManager package from the database.
         
-    .PARAMETER Name
+    .PARAMETER PackageName
         The name of the ProgramManager package to install.
         
     .PARAMETER ShowUI
@@ -72,6 +72,11 @@
     
     # Iterate through all passed package names
     foreach ($name in $PackageName) {
+        
+        # Check if the package has a pre-install scriptblock and run it
+        if ($null -ne $package.PreInstallScriptblock) {
+            Invoke-Command -ScriptBlock $package.PreInstallScriptblock #-ArgumentList
+        }
     
         # Get the package by name
         $package = $packageList | Where-Object { $_.Name -eq $name }
@@ -169,10 +174,10 @@
             
         }
         
-        #
-        #! At some point, add support for post-install scriptblock execution
-        #       -> mainly for the copying of shortcuts, startup, setting symlink folders etc
-        #
+        # Check if the package has a post-install scriptblock and run it
+        if ($null -ne $package.PostInstallScriptblock) {
+            Invoke-Command -ScriptBlock $package.PostInstallScriptblock #-ArgumentList
+        }
         
         # Set the installed flag for the package
         $package.IsInstalled = $true

--- a/ProgramManager/functions/Invoke-PMInstall.ps1
+++ b/ProgramManager/functions/Invoke-PMInstall.ps1
@@ -23,8 +23,8 @@
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true, Position = 0)]
-        [string]
-        $Name,
+        [string[]]
+        $PackageName,
         
         [Parameter(Position = 1)]
         [switch]
@@ -70,108 +70,114 @@
         
     }
     
-    # Get the package by name
-    $package = $packageList | Where-Object { $_.Name -eq $Name }
-    if ($null -eq $package) {
-        "There is no package called: $Name" | Write-Error
-        break
-    }
+    # Iterate through all passed package names
+    foreach ($name in $PackageName) {
     
-    # If its a url package, download it and set some properties to allow the installation code to run
-    if ($package.Type -eq "UrlPackage") {
-        
-        # Get the absolute url after any redirection
-        $url = [System.Net.HttpWebRequest]::Create($package.Url).GetResponse().ResponseUri.AbsoluteUri
-        
-        # Get the file extension in order to save it correctly
-        $regex = [regex]::Match($url, ".*\.(.*)")
-        $extension = $regex.Groups[1].Value
-        
-        # Download the installer from the url    
-        Invoke-WebRequest -Uri $url -OutFile "$dataPath\$($package.Name)\installer.$extension"
-        
-        # Set executable properties in the package object to allow later code to run correctly
-        $package | Add-Member -Type NoteProperty -Name "ExecutableName" -Value "installer.$extension"
-        $package | Add-Member -Type NoteProperty -Name "ExecutableType" -Value $extension
-        
-    }
-    
-    # Installation logic
-    if ($package.Type -eq "LocalPackage" -or $package.Type -eq "UrlPackage") {
-        
-        if ($package.ExecutableType -eq ".exe") {
-            
-            # Start the exe installer
-            Start-Process -FilePath $dataPath\$package.Name\$package.ExecutableName
-            
-        }elseif ($package.ExecutableType -eq ".msi") {
-                        
-            # Set the display argument for msiexec
-            if ($ShowUI -eq $true) {
-                $dislayArgument = "/qr "
-            }else {
-                $dislayArgument = "/qn "
-            }
-            
-            # Set the logging argument for msiexec
-            if ($NoLog -eq $true) {
-                $logArgument = ""
-            }else {
-                $logArgument = "/l*v `"$dataPath\install-$($apckage.Name)-$(Get-Date -Format "yyyy/MM/dd HH:mm").txt`""
-            }
-            
-            # If the package has a defined install directory, set the msiexec argument(s) to that
-            if ([System.String]::IsNullOrWhiteSpace($package.InstallDirectory) -eq $false) {
-                $paramArgument += "INSTALL_PREFIX_1=`"$($package.InstallDirectory)`" "
-                $paramArgument += "TARGETDIR=`"$($package.InstallDirectory)`" "
-                $paramArgument += "INSTALLDIR=`"$($package.InstallDirectory)`" "
-                $paramArgument += "INSTALLDIRECTORY=`"$($package.InstallDirectory)`" "
-                $paramArgument += "TARGETDIRECTORY=`"$($package.InstallDirectory)`" "
-                $paramArgument += "TARGETPATH=`"$($package.InstallDirectory)`" "
-                $paramArgument += "INSTALLPATH=`"$($package.InstallDirectory)`" "  
-            }
-            
-            # Set the msiexec arguments
-            $processStartupInfo = New-Object System.Diagnostics.ProcessStartInfo -Property @{
-                FileName = "msiexec.exe"
-                Arguments = "$dataPath\packages\$($package.Name)\$($package.ExecutableName) " + $dislayArgument + $logArgument + $paramArgument
-                UseShellExecute = $false
-            }
-            
-            # Start msiexec and wait until it's finished
-            $process = New-Object System.Diagnostics.Process
-            $process.StartInfo = $processStartupInfo
-            $process.Start()
-            
-            $process.WaitForExit()
-            $process.Dispose()
-                        
-        }
-        
-    }elseif ($package.Type -eq "PortablePackage") {
-        
-        # Check that the install directory exists, otherwise abort
-        if ((Test-Path -Path $package.InstallDirectory) -eq $false) {
-            "The install directory is invalid: $($package.InstallDirectory)" | Write-Error
+        # Get the package by name
+        $package = $packageList | Where-Object { $_.Name -eq $name }
+        if ($null -eq $package) {
+            "There is no package called: $Name" | Write-Error
             break
         }
+        
+        # If its a url package, download it and set some properties to allow the installation code to run
+        if ($package.Type -eq "UrlPackage") {
+            
+            # Get the absolute url after any redirection
+            $url = [System.Net.HttpWebRequest]::Create($package.Url).GetResponse().ResponseUri.AbsoluteUri
+            
+            # Get the file extension in order to save it correctly
+            $regex = [regex]::Match($url, ".*\.(.*)")
+            $extension = $regex.Groups[1].Value
+            
+            # Download the installer from the url    
+            Invoke-WebRequest -Uri $url -OutFile "$dataPath\$($package.Name)\installer.$extension"
+            
+            # Set executable properties in the package object to allow later code to run correctly
+            $package | Add-Member -Type NoteProperty -Name "ExecutableName" -Value "installer.$extension"
+            $package | Add-Member -Type NoteProperty -Name "ExecutableType" -Value $extension
+            
+        }
+        
+        # Installation logic
+        if ($package.Type -eq "LocalPackage" -or $package.Type -eq "UrlPackage") {
+            
+            if ($package.ExecutableType -eq ".exe") {
                 
-        # Copy package folder to install directory
-        Copy-Item -Path "$dataPath\packages\$($package.Name)" -Destination $package.InstallDirectory -Container -Recurse
+                # Start the exe installer
+                Start-Process -FilePath $dataPath\$package.Name\$package.ExecutableName
+                
+            }elseif ($package.ExecutableType -eq ".msi") {
+                            
+                # Set the display argument for msiexec
+                if ($ShowUI -eq $true) {
+                    $dislayArgument = "/qr "
+                }else {
+                    $dislayArgument = "/qn "
+                }
+                
+                # Set the logging argument for msiexec
+                if ($NoLog -eq $true) {
+                    $logArgument = ""
+                }else {
+                    $logArgument = "/l*v `"$dataPath\install-$($apckage.Name)-$(Get-Date -Format "yyyy/MM/dd HH:mm").txt`""
+                }
+                
+                # If the package has a defined install directory, set the msiexec argument(s) to that
+                if ([System.String]::IsNullOrWhiteSpace($package.InstallDirectory) -eq $false) {
+                    $paramArgument += "INSTALL_PREFIX_1=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "TARGETDIR=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "INSTALLDIR=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "INSTALLDIRECTORY=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "TARGETDIRECTORY=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "TARGETPATH=`"$($package.InstallDirectory)`" "
+                    $paramArgument += "INSTALLPATH=`"$($package.InstallDirectory)`" "  
+                }
+                
+                # Set the msiexec arguments
+                $processStartupInfo = New-Object System.Diagnostics.ProcessStartInfo -Property @{
+                    FileName = "msiexec.exe"
+                    Arguments = "$dataPath\packages\$($package.Name)\$($package.ExecutableName) " + $dislayArgument + $logArgument + $paramArgument
+                    UseShellExecute = $false
+                }
+                
+                # Start msiexec and wait until it's finished
+                $process = New-Object System.Diagnostics.Process
+                $process.StartInfo = $processStartupInfo
+                $process.Start()
+                
+                $process.WaitForExit()
+                $process.Dispose()
+                            
+            }
+            
+        }elseif ($package.Type -eq "PortablePackage") {
+            
+            # Check that the install directory exists, otherwise abort
+            if ((Test-Path -Path $package.InstallDirectory) -eq $false) {
+                "The install directory is invalid: $($package.InstallDirectory)" | Write-Error
+                break
+            }
+                    
+            # Copy package folder to install directory
+            Copy-Item -Path "$dataPath\packages\$($package.Name)" -Destination $package.InstallDirectory -Container -Recurse
+            
+        }elseif ($package.Type -eq "ChocolateyPackage") {
+            
+            # Invoke chocolatey
+            choco install $pacakge.PackageName
+            
+        }
         
-    }elseif ($package.Type -eq "ChocolateyPackage") {
+        #
+        #! At some point, add support for post-install scriptblock execution
+        #       -> mainly for the copying of shortcuts, startup, setting symlink folders etc
+        #
         
-        #! TODO
-        
+        # Set the installed flag for the package
+        $package.IsInstalled = $true
+    
     }
-    
-    #
-    #! At some point, add support for post-install scriptblock execution
-    #       -> mainly for the copying of shortcuts, startup, setting symlink folders etc
-    #
-    
-    # Set the installed flag for the package
-    $package.IsInstalled = $true
     
     # Export-out package list (with modified package) to xml file
 	Export-Data -Object $packageList -Path "$dataPath\packageDatabase.xml" -Type "Clixml"	

--- a/ProgramManager/functions/Invoke-PMInstall.ps1
+++ b/ProgramManager/functions/Invoke-PMInstall.ps1
@@ -1,0 +1,88 @@
+﻿function Invoke-PMInstall {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]
+        $Name
+    )
+    
+    $dataPath = "$env:USERPROFILE\ProgramManager"
+        
+    # Create list of all PMProgram objects
+	$packageList = [System.Collections.Generic.List[psobject]]@()
+	
+	# Check if the xml database already exists
+    if ((Test-Path -Path "$dataPath\packageDatabase.xml") -eq $true) {
+        
+		# The xml database exists
+		# Load all existing PMPrograms into a list
+		$xmlData = Import-Data -Path "$dataPath\packageDatabase.xml" -Type "Clixml"
+		
+		# Iterate through all imported objects
+		foreach ($obj in $xmlData) {
+			# Only operate on PMProgram objects
+			if ($obj.psobject.TypeNames[0] -eq "Deserialized.ProgramManager.Package") {
+				# Create new PMProgram objects
+				$existingPackage = New-Object -TypeName psobject 
+				$existingPackage.PSObject.TypeNames.Insert(0, "ProgramManager.Package")
+				
+				# Copy the properties from the Deserialized object into the new one
+				foreach ($property in $obj.psobject.Properties) {
+					$existingPackage | Add-Member -Type NoteProperty -Name $property.Name -Value $property.Value
+				}
+				
+                $packageList.Add($existingPackage)
+                
+			}
+		}
+		
+	}else {
+        
+        # The xml database doesn't exist, abort
+        "The database file doesn't exist. Run Add-PMProgram to initialise it." | Write-Error
+        break
+        
+    }
+    
+    # Get the package by name
+    $package = $packageList | Where-Object { $_.Name -eq $Name }
+    if ($null -eq $package) {
+        "There is no package called: $Name" | Write-Error
+        break
+    }
+    
+    if ($package.Type -eq "LocalPackage") {
+        
+        if ($package.ExecutableType -eq ".exe") {
+            
+        }elseif ($package.ExecutableType -eq ".msi") {
+            
+            msiexec.exe /i "$dataPath\packages\$($package.Name)\$($package.ExecutableName)" /qb /l*v "$dataPath\latestlog.txt" PARAMETERS
+            
+        }
+        
+    }elseif ($package.Type -eq "UrlPackage") {
+        
+        
+    }elseif ($package.Type -eq "PortablePackage") {
+        
+        # Check that the install directory exists, otherwise abort
+        if ((Test-Path -Path $package.InstallDirectory) -eq $false) {
+            "The install directory is invalid: $($package.InstallDirectory)" | Write-Error
+            break
+        }
+                
+        # Copy package folder to install directory
+        Copy-Item -Path "$dataPath\packages\$($package.Name)" -Destination $package.InstallDirectory -Container -Recurse
+        
+        #
+        #! At some point, add support for post-install scriptblock execution
+        #       -> mainly for the copying of shortcuts, startup etc
+        
+    }elseif ($package.Type -eq "ChocolateyPackage") {
+        
+        
+    }
+            
+    
+}

--- a/ProgramManager/internal/tepp/assignment.ps1
+++ b/ProgramManager/internal/tepp/assignment.ps1
@@ -1,4 +1,1 @@
-﻿<#
-# Example:
-Register-PSFTeppArgumentCompleter -Command Get-Alcohol -Parameter Type -Name ProgramManager.alcohol
-#>
+﻿Register-ArgumentCompleter -CommandName Invoke-PMInstall -ParameterName Name -ScriptBlock $argCompleter_PackageNames

--- a/ProgramManager/internal/tepp/example.tepp.ps1
+++ b/ProgramManager/internal/tepp/example.tepp.ps1
@@ -1,4 +1,0 @@
-﻿<#
-# Example:
-Register-PSFTeppScriptblock -Name "ProgramManager.alcohol" -ScriptBlock { 'Beer','Mead','Whiskey','Wine','Vodka','Rum (3y)', 'Rum (5y)', 'Rum (7y)' }
-#>

--- a/ProgramManager/internal/tepp/scriptblocks.ps1
+++ b/ProgramManager/internal/tepp/scriptblocks.ps1
@@ -1,0 +1,40 @@
+﻿$argCompleter_PackageNames = {
+    param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    
+    # Create list of all PMProgram objects
+	$packageList = [System.Collections.Generic.List[psobject]]@()
+    
+    # Check if the xml database already exists
+    if ((Test-Path -Path "$dataPath\packageDatabase.xml") -eq $true) {
+        
+		# The xml database exists
+		# Load all existing PMPrograms into a list
+		$xmlData = Import-Data -Path "$dataPath\packageDatabase.xml" -Type "Clixml"
+		
+		# Iterate through all imported objects
+		foreach ($obj in $xmlData) {
+			# Only operate on PMProgram objects
+			if ($obj.psobject.TypeNames[0] -eq "Deserialized.ProgramManager.Package") {
+				# Create new PMProgram objects
+				$existingPackage = New-Object -TypeName psobject 
+				$existingPackage.PSObject.TypeNames.Insert(0, "ProgramManager.Package")
+				
+				# Copy the properties from the Deserialized object into the new one
+				foreach ($property in $obj.psobject.Properties) {
+					$existingPackage | Add-Member -Type NoteProperty -Name $property.Name -Value $property.Value
+				}
+				
+                $packageList.Add($existingPackage)
+                
+			}
+		}
+		
+	}else {
+        
+        return ""
+                
+    }
+    
+    $packageList | Where-Object { $_.Name -like "$wordToComplete*" }
+    
+}

--- a/ProgramManager/notes.txt
+++ b/ProgramManager/notes.txt
@@ -1,3 +1,0 @@
-﻿msiexec /i <path> /qb /l*v <log> <params>
-    msiexec parameters
-        blender: INSTALL_PREFIX_1="<Path>"


### PR DESCRIPTION
Implemented Invoke-PMInstall:
- Added support for installing different types of programs (local, url, portable, chocolatey).
- Supports installing multiple packages with one command.
- Runs pre- and post- install scriptblocks to automate manual tasks (if necessary).
- Added support for tab completion for package names.

Modified Add-PMPorgram:
- Refactored parameters and sets to reduce duplication.
- Modified psobject properties depending on what sort of package it is.

General:
- Changed naming scheme from *program to *package to make all variables/names etc follow the same pattern and have clearer meaning.