### PR TITLE
Release v0.1.2 FIXED

### DIFF
--- a/ProgramManager/ProgramManager.psm1
+++ b/ProgramManager/ProgramManager.psm1
@@ -14,6 +14,7 @@ if ((Test-Path -Path $script:DataPath) -eq $false) {
 
 # Detect whether at some level dotsourcing was enforced
 $script:doDotSource = $global:ModuleDebugDotSource
+$script:doDotSource = $true # Needed to make code coverage tests work
 # Detect whether at some level loading individual module files, rather than the compiled module was enforced
 $importIndividualFiles = $global:ModuleDebugIndividualFiles
 

--- a/ProgramManager/tests/pester.ps1
+++ b/ProgramManager/tests/pester.ps1
@@ -23,8 +23,8 @@ Write-Host "Starting Tests"
 # Remove and re-import the module
 Write-Host "Importing Module"
 Remove-Module ProgramManager -ErrorAction Ignore
-Import-Module "$PSScriptRoot\..\ProgramManager.psd1"
-Import-Module "$PSScriptRoot\..\ProgramManager.psm1" -Force
+Import-Module "$PSScriptRoot\..\ProgramManager.psd1" -Verbose
+Import-Module "$PSScriptRoot\..\ProgramManager.psm1" -Force -Verbose
 
 # Create the test results directory
 Write-Host "Creating test result folder"

--- a/build/vsts-build.ps1
+++ b/build/vsts-build.ps1
@@ -34,6 +34,11 @@ if (-not $WorkingDirectory) {
 }
 
 #=======================
+# Install modules
+Install-Module "PowershellGet" -SkipPublisherCheck -Force -RequiredVersion "2.2.2" -Verbose
+Import-Module "PowershellGet" -RequiredVersion "2.2.2" -Force -Verbose
+
+#=======================
 # Prepare publish folder
 Write-Host "Creating and populating publishing directory"
 Remove-Item -Path "$WorkingDirectory\publish" -Force -Recurse -ErrorAction SilentlyContinue
@@ -131,25 +136,25 @@ if ($SkipPublish -eq $false) {
 		Write-Host "Publishing the ProgramManager module to TEST PSGallery"
 		
 		# Register testing repository
-		Register-PSRepository -Name "test-repo" -SourceLocation "https://www.poshtestgallery.com/api/v2" -PublishLocation "https://www.poshtestgallery.com/api/v2/package" -InstallationPolicy Trusted
-		Publish-Module -Path "$($publishDir.FullName)\ProgramManager" -NuGetApiKey $ApiKey -Force -Repository "test-repo"
+		Register-PSRepository -Name "test-repo" -SourceLocation "https://www.poshtestgallery.com/api/v2" -PublishLocation "https://www.poshtestgallery.com/api/v2/package" -InstallationPolicy Trusted -Verbose
+		Publish-Module -Path "$($publishDir.FullName)\ProgramManager" -NuGetApiKey $ApiKey -Force -Repository "test-repo" -Verbose
 		
 		Write-Host "Published package to test repo. Waiting 30 seconds."
 		Start-Sleep -Seconds 30
 		
 		# Uninstall module if it already exists, to then install the test-module
-		Uninstall-Module -Name "ProgramManager" -Force
-		Install-Module -Name "ProgramManager" -Repository "test-repo" -Force -AcceptLicense -SkipPublisherCheck
+		Uninstall-Module -Name "ProgramManager" -Force -Verbose
+		Install-Module -Name "ProgramManager" -Repository "test-repo" -Force -AcceptLicense -SkipPublisherCheck -Verbose
 		Write-Host "Test ProgramManager module installed"
 		
 		# Remove the testing repository
-		Unregister-PSRepository -Name "test-repo"
+		Unregister-PSRepository -Name "test-repo" -Verbose
 		
 	}else {
 		
 		# Publish to PSGallery
 		Write-Host "Publishing the ProgramManager module to $($Repository)"
-		Publish-Module -Path "$($publishDir.FullName)\ProgramManager" -NuGetApiKey $ApiKey -Force -Repository $Repository
+		Publish-Module -Path "$($publishDir.FullName)\ProgramManager" -NuGetApiKey $ApiKey -Force -Repository $Repository -Verbose
 		
 	}
 
@@ -162,10 +167,10 @@ if ($SkipArtifact -eq $false) {
 	$moduleVersion = (Import-PowerShellDataFile -Path "$PSScriptRoot\..\ProgramManager\ProgramManager.psd1").ModuleVersion
 	# Move the module contents to the desired folder structure
 	New-Item -ItemType Directory -Path "$($publishDir.FullName)\ProgramManager\" -Name "$moduleVersion" -Force
-	Move-Item -Path "$($publishDir.FullName)\ProgramManager\*" -Destination "$($publishDir.FullName)\ProgramManager\$moduleVersion\" -Exclude "*$moduleVersion*" -Force
+	Move-Item -Path "$($publishDir.FullName)\ProgramManager\*" -Destination "$($publishDir.FullName)\ProgramManager\$moduleVersion\" -Exclude "*$moduleVersion*" -Force -Verbose
 	
 	# Create a packaged zip file
-	Compress-Archive -Path "$($publishDir.FullName)\ProgramManager" -DestinationPath "$($publishDir.FullName)\ProgramManager-v$($moduleVersion).zip"
+	Compress-Archive -Path "$($publishDir.FullName)\ProgramManager" -DestinationPath "$($publishDir.FullName)\ProgramManager-v$($moduleVersion).zip" -Verbose
 	
 	# Write the module number as a azure pipeline variable for publish task
 	Write-Host "##vso[task.setvariable variable=version;isOutput=true]$moduleVersion"

--- a/build/vsts-prerequisites.ps1
+++ b/build/vsts-prerequisites.ps1
@@ -1,11 +1,8 @@
-﻿# The modules which are required for testing
-$modules = @("Pester", "PSScriptAnalyzer")
+﻿# Install each module
+Write-Host "Installing Pester" -ForegroundColor Cyan
+Install-Module "Pester" -Force -SkipPublisherCheck -Verbose
+Import-Module "Pester" -Force -PassThru -Verbose
 
-# Install each module
-foreach ($module in $modules) {
-    
-    Write-Host "Installing $module" -ForegroundColor Cyan
-    Install-Module $module -Force -SkipPublisherCheck
-    Import-Module $module -Force -PassThru
-    
-}
+Write-Host "Installing PSScriptAnalyzer" -ForegroundColor Cyan
+Install-Module "PSScriptAnalyzer" -Force -SkipPublisherCheck -Verbose
+Import-Module "PSScriptAnalyzer" -Force -PassThru -Verbose


### PR DESCRIPTION
Made PowershellGet require v2.2.2 to avoid hanging.
Made all commands produce verbose output for easier debugging.
Enabled dotsource flag in .psm1 to allow code coverage tests to work again.